### PR TITLE
Added JBOD status

### DIFF
--- a/check_lsi_raid
+++ b/check_lsi_raid
@@ -578,7 +578,7 @@ sub getPDStatus{
 	my $status = '';
 	foreach my $PD (@foundPDs){
 		if(exists($PD->{'State'})){
-			if($PD->{'State'} ne 'Onln' && $PD->{'State'} ne 'UGood' && $PD->{'State'} ne 'GHS' && $PD->{'State'} ne 'DHS'){
+			if($PD->{'State'} ne 'Onln' && $PD->{'State'} ne 'UGood' && $PD->{'State'} ne 'GHS' && $PD->{'State'} ne 'DHS' && $PD->{'State'} ne 'JBOD'){
 				$status = 'Critical';
 				push @{$statusLevel_a[2]}, $PD->{'pd'}.'_State';
 				$statusLevel_a[3]->{$PD->{'pd'}.'_State'} = $PD->{'State'};


### PR DESCRIPTION
Hi,

I have added the JBOD status to your check. I'm using the JBOD status in a ceph cluster and used your script in my nagios setup but it failed due to the JBOD status. JBOD status is very common in ceph cluster setups as each disk is addressed seperatly. Just want to make things a little better.