### PR TITLE
Change regex for check_lsi_raid (Failure 46)

### DIFF
--- a/check_lsi_raid
+++ b/check_lsi_raid
@@ -195,7 +195,7 @@ sub checkCommandStatus{
 			if($line eq "Status = Success\n"){
 				return 1;
 			}
-			elsif (grep { /Failure\s+46/i } @output){
+			elsif (grep { /Fail(ed|ure)\s+46/i } @output){
 				# Return 46 means a drive is not attached, this is a valid failure
 				return 1;
 			}


### PR DESCRIPTION
Change regex on "Failure 46" for check_lsi_raid to work with last storcli client (Ver 1.21.06)